### PR TITLE
fix: 完善iOS设置角标的方法

### DIFF
--- a/ios/AliyunReactNativePush.mm
+++ b/ios/AliyunReactNativePush.mm
@@ -497,8 +497,21 @@ RCT_REMAP_METHOD(setBadgeNum,
                  setBadgeNumWithNum:(int)num
                  setBadgeNumWithResolver:(RCTPromiseResolveBlock)resolve
                  setBadgeNumWithRejecter:(RCTPromiseRejectBlock)reject) {
-    RCTSharedApplication().applicationIconBadgeNumber = num;
-    resolve(@{KEY_CODE: CODE_SUCCESS});
+    if (@available(iOS 16.0, *)) {
+        UNUserNotificationCenter *_notificationCenter = [UNUserNotificationCenter currentNotificationCenter];
+        [_notificationCenter setBadgeCount:num withCompletionHandler:^(NSError * _Nullable error) {
+            if (error == nil) {
+                resolve(@{KEY_CODE: CODE_SUCCESS});
+            } else {
+                resolve(@{KEY_CODE:CODE_FAILED, KEY_ERROR_MSG: error.localizedDescription});
+            }
+        }];
+    } else {
+        RCTExecuteOnMainQueue(^{
+            RCTSharedApplication().applicationIconBadgeNumber = num;
+            resolve(@{KEY_CODE: CODE_SUCCESS});
+        });
+    }
 }
 
 RCT_REMAP_METHOD(syncBadgeNum,


### PR DESCRIPTION
1. 在 `iOS 16+` 的系统上使用 [`setBadgeCount:withCompletionHandler:`](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/setbadgecount(_:withcompletionhandler:)?language=objc)
2. 遵循 Xcode 的修改建议，把设置角标的旧方法移到 mainQueue 里执行