### PR TITLE
fix: 将 Android 仓库地址切换为 maven.aliyun.com 新版路径

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,7 +84,7 @@ android {
 repositories {
   mavenCentral()
   google()
-  maven { url 'https://maven.aliyun.com/nexus/content/repositories/releases/' }
+  maven { url 'https://maven.aliyun.com/repository/releases' }
   maven { url 'https://developer.huawei.com/repo/' }
   maven { url 'https://developer.hihonor.com/repo' }
 }


### PR DESCRIPTION
## 问题

`android/build.gradle` 使用的是 `maven.aliyun.com` 的旧版兼容路径 `/nexus/content/repositories/releases/`。该路径在 GitHub 托管的 CI 机器上会间歇性返回 **HTTP 502**。

2026-07-30 相隔约 40 分钟的两次构建，在解析 `com.aliyun.ams:alicloud-android-third-push` 的元数据时都收到 502：

```
Could not resolve com.aliyun.ams:alicloud-android-third-push:3.10.2
> Could not GET 'https://maven.aliyun.com/nexus/content/repositories/releases/com/aliyun/ams/alicloud-android-third-push/3.10.2/alicloud-android-third-push-3.10.2.module'
  Received status code 502 from server: Bad Gateway
```

同一次构建中，新版路径 `/repository/releases` 全程正常。

## 为什么影响面比较大

Gradle 对 5xx 和 404 的处理不同：遇到 5xx 会**禁用该仓库并让整条依赖解析直接失败**，而不是像 404 那样跳过继续。结果是本模块声明的九个 `com.aliyun.ams` 依赖会一起解析失败：

```
Could not determine the dependencies of task ':aliyun-react-native-push:extractReleaseAnnotations'
> Repository maven6 is disabled due to earlier error below
```

而且**使用方无法在自己的工程里兜底**——即使另外声明了可用的镜像并配置了 `includeGroupByRegex` 允许它提供 `com.aliyun.*`，Gradle 也不会回退到那个仓库，构建仍然失败。所以只能从声明里去掉这个地址。

## 修改内容

一行地址替换，指向阿里云文档给出的新版路径：

```diff
-  maven { url 'https://maven.aliyun.com/nexus/content/repositories/releases/' }
+  maven { url 'https://maven.aliyun.com/repository/releases' }
```

## 验证

本模块声明的九个构件在新版路径下的 `maven-metadata.xml` 均可正常获取，可以直接替换：

| 构件 | `/repository/releases` |
| --- | --- |
| `alicloud-android-push` | 200 |
| `alicloud-android-third-push` | 200 |
| `alicloud-android-third-push-meizu` | 200 |
| `alicloud-android-third-push-vivo` | 200 |
| `alicloud-android-third-push-oppo` | 200 |
| `alicloud-android-third-push-xiaomi` | 200 |
| `alicloud-android-third-push-huawei` | 200 |
| `alicloud-android-third-push-honor` | 200 |
| `alicloud-android-third-push-fcm` | 200 |

需要说明的是：旧版路径目前从部分网络位置访问仍然是正常的，502 是间歇性的、且与访问来源有关。上面的证据来自 GitHub 托管 runner 上的两次连续失败。本 PR 只改构建脚本，不涉及 API 或运行时行为。

## 可选的后续（不在本 PR 范围内）

这三个仓库声明没有 repository content filter，因此 Gradle 在解析本模块的**所有**依赖（`react-android`、`kotlin-stdlib`、androidx 等）时都会先探测这些镜像。加上 `content { includeGroupByRegex(...) }` 可以把它们限制在各自的 group 上，既能减少不必要的请求，也能缩小镜像故障的影响面。如果维护者认为合适，我可以另开一个 PR。

---

## Summary (English)

`android/build.gradle` points at `maven.aliyun.com`'s legacy alias `/nexus/content/repositories/releases/`, which intermittently returns **HTTP 502** from GitHub-hosted CI runners — observed twice ~40 minutes apart on 2026-07-30 while the modern `/repository/releases` endpoint stayed healthy in the same build.

This cascades badly because Gradle disables a repository on 5xx (unlike 404) **and fails the resolution outright**, so all nine `com.aliyun.ams` dependencies fail together. Consumers cannot work around it: declaring a healthy mirror with `includeGroupByRegex` for `com.aliyun.*` does not rescue the build, because Gradle won't fall back to a sibling repo. The broken URL has to be absent.

This PR is a one-line swap to the endpoint Aliyun documents. All nine declared artifacts serve `maven-metadata.xml` from it (table above). Build-script only — no API or runtime change.

Optional follow-up, happy to open separately: these three repos carry no content filter, so Gradle probes the CN mirrors for *every* artifact this module resolves. Adding `content { includeGroupByRegex(...) }` would scope them to their own groups and shrink the blast radius of any mirror outage.